### PR TITLE
[PUWEN-1504]: avrogen: optional maps

### DIFF
--- a/lib/avrogen/avro/types/union.ex
+++ b/lib/avrogen/avro/types/union.ex
@@ -66,11 +66,6 @@ defimpl CodeGenerator, for: Union do
 
     quote do
       (unquote_splicing(functions))
-
-      # This is not correct behaviour, but is the current behaviour of the library.
-      # We should remove this and return and error simply have a match failure in a
-      # future release
-      defp unquote(function_name)(value), do: value
     end
   end
 

--- a/test/avro/types/union_test.exs
+++ b/test/avro/types/union_test.exs
@@ -40,5 +40,19 @@ defmodule Avrogen.Avro.Types.UnionTest do
         assert union == test_encode_union_primitives(val)
       end)
     end
+
+    test "union function clause error trying to encode a non-union type" do
+      assert_raise FunctionClauseError, fn ->
+        # It's a union of null, string, bool and numbers. Map isn't an union value.
+        # Instead of returning the value itself, it should return an error.
+        test_encode_union_primitives(%{})
+      end
+    end
+
+    test "union function clause error trying to decode a non-union type" do
+      # assert {:error, _} = test_decode_union_primitives(%{})
+      # Note: that's not the correct behavior. The function should return an error.
+      assert {:ok, %{}} = test_decode_union_primitives(%{})
+    end
   end
 end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PUWEN-1504

This is the easiest solution to fix this warning. I think we should remove this function [here](https://github.com/primait/avrogen/blob/ba6c7409d59214b06aa4a71c4543bf380fe3963d/lib/avrogen/avro/types/union.ex#L96) and let the team that uses this tool fix their test errors.