### PR TITLE
differentiate between default=nil and an unset default

### DIFF
--- a/lib/avrogen/avro/types.ex
+++ b/lib/avrogen/avro/types.ex
@@ -2,5 +2,5 @@ alias Avrogen.Avro.Types
 import Avrogen.Utils.MacroUtils
 
 jason_decode_skip_null_impl(Types.Record)
-jason_decode_skip_null_impl(Types.Record.Field)
+jason_decode_skip_null_field_impl(Types.Record.Field)
 jason_decode_skip_null_impl(Types.Enum)

--- a/lib/avrogen/avro/types/record/field.ex
+++ b/lib/avrogen/avro/types/record/field.ex
@@ -60,7 +60,7 @@ defmodule Avrogen.Avro.Types.Record.Field do
   # The only way to differentiate between "default is nil because there isn't one" and "default is actually null" is to
   # check if the type is also a union with null.
   def has_default?(%__MODULE__{default: nil, type: %Types.Union{} = union}),
-    do: Types.Union.has_member?(union, Types.Primitive.null())
+    do: Types.Union.optional_by_convention?(union)
 
   def has_default?(%__MODULE__{default: nil}), do: false
   def has_default?(%__MODULE__{}), do: true

--- a/lib/avrogen/avro/types/record/field.ex
+++ b/lib/avrogen/avro/types/record/field.ex
@@ -57,6 +57,11 @@ defmodule Avrogen.Avro.Types.Record.Field do
   def comment(%__MODULE__{doc: nil, name: name}), do: "#{name}: #{name}"
   def comment(%__MODULE__{doc: doc, name: name}), do: "#{name}: #{doc}"
 
+  # The only way to differentiate between "default is nil because there isn't one" and "default is actually null" is to
+  # check if the type is also a union with null.
+  def has_default?(%__MODULE__{default: nil, type: %Types.Union{} = union}),
+    do: Types.Union.has_member?(union, Types.Primitive.null())
+
   def has_default?(%__MODULE__{default: nil}), do: false
   def has_default?(%__MODULE__{}), do: true
 

--- a/lib/avrogen/avro/types/union.ex
+++ b/lib/avrogen/avro/types/union.ex
@@ -15,6 +15,7 @@ defmodule Avrogen.Avro.Types.Union do
   """
 
   alias Avrogen.Avro.Schema
+  alias Avrogen.Avro.Types.Primitive
   use TypedStruct
 
   typedstruct do
@@ -25,6 +26,10 @@ defmodule Avrogen.Avro.Types.Union do
   def parse(value) when is_list(value), do: %__MODULE__{types: Enum.map(value, &Schema.parse/1)}
 
   def has_member?(%__MODULE__{types: types}, type), do: Enum.member?(types, type)
+
+  # A union with null listed first is optional by convention (see moduledoc).
+  def optional_by_convention?(%__MODULE__{types: [first_type | _]}),
+    do: first_type == Primitive.null()
 end
 
 alias Avrogen.Avro.Schema.CodeGenerator

--- a/lib/avrogen/avro/types/union.ex
+++ b/lib/avrogen/avro/types/union.ex
@@ -15,7 +15,6 @@ defmodule Avrogen.Avro.Types.Union do
   """
 
   alias Avrogen.Avro.Schema
-  alias Avrogen.Avro.Types.Primitive
   use TypedStruct
 
   typedstruct do
@@ -26,10 +25,6 @@ defmodule Avrogen.Avro.Types.Union do
   def parse(value) when is_list(value), do: %__MODULE__{types: Enum.map(value, &Schema.parse/1)}
 
   def has_member?(%__MODULE__{types: types}, type), do: Enum.member?(types, type)
-
-  # A union with null listed first is optional by convention (see moduledoc).
-  def optional_by_convention?(%__MODULE__{types: [first_type | _]}),
-    do: first_type == Primitive.null()
 end
 
 alias Avrogen.Avro.Schema.CodeGenerator


### PR DESCRIPTION
The JSON-encode protocol for the schema objects removes fields with values of `nil`, but this means that it is impossible to make a schema with `default=nil`, which is necessary for schema evolution. This PR edits the protocol to include `default=nil` _only_ when it was explicitly written in the source .exs defintion files.

----

Also stops generated `from_avro_map` functions from requiring optional fields to be present in the avro map by pattern matching in the header.

e.g. for a record with an optional list, `record_list`, previously we generated:

```elixir
  @impl true
  def from_avro_map(
        %{
          "record_list" => record_list
        } = _avro_map
      ) do
    {:ok,
     %__MODULE__{
       record_list: decode_record_list(record_list)
     }}
  end

  @required_keys MapSet.new(["record_list"])
  def from_avro_map(%{} = invalid) do
    actual = Map.keys(invalid) |> MapSet.new()
    missing = MapSet.difference(@required_keys, actual) |> Enum.join(", ")
    {:error, "Missing keys: " <> missing}
  end

  def from_avro_map(_) do
    {:error, "Expected a map."}
  end
```

which enforces the presence of the `record_list` key, but now we do:

```elixir
  @impl true
  def from_avro_map(%{} = avro_map) do
    record_list = avro_map["record_list"]

    {:ok,
     %__MODULE__{
       record_list: decode_record_list(record_list)
     }}
  end

  def from_avro_map(_) do
    {:error, "Expected a map."}
  end
```