### PR TITLE
feat: removed noether dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.8.2] - 2025-03-27
+
+### Fixed
+
+- Removed Noether dependency to avoid conflicts.
+
+---
+
 ## [0.8.1] - 2025-02-25
 
 ### Fixed
@@ -62,7 +70,9 @@ and this project adheres to
   - `LocalTimestampMillis` (`long`).
   - `LocalTimestampMicros` (`long`).
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.8.1...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/0.8.2...HEAD
+[0.8.2]: https://github.com/primait/avrogen/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/primait/avrogen/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/primait/avrogen/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/primait/avrogen/compare/0.6.6...0.7.0

--- a/lib/avrogen.ex
+++ b/lib/avrogen.ex
@@ -19,6 +19,7 @@ defmodule Avrogen do
   """
 
   alias Avrogen.Schema.SchemaRegistry
+  alias Avrogen.Util.Either
 
   def encode_schemaless(%module{} = record) do
     encoder = SchemaRegistry.get_encoder()
@@ -32,7 +33,7 @@ defmodule Avrogen do
   def encode_schemaless_base64(%_{} = record) do
     record
     |> encode_schemaless()
-    |> Noether.Either.map(fn iodata ->
+    |> Either.map(fn iodata ->
       iodata
       |> IO.iodata_to_binary()
       |> Base.encode64()

--- a/lib/avrogen/schema.ex
+++ b/lib/avrogen/schema.ex
@@ -4,6 +4,8 @@ defmodule Avrogen.Schema do
   Schemas can be records or enums.
   """
 
+  alias Avrogen.Util.Either
+
   @type schema() :: map()
 
   @doc """
@@ -83,7 +85,7 @@ defmodule Avrogen.Schema do
       false -> {:error, :cyclic_dependencies}
       sorted -> {:ok, sorted}
     end
-    |> Noether.Either.map(fn sorted ->
+    |> Either.map(fn sorted ->
       sorted
       |> Enum.map(fn name ->
         {_, item, _} = List.keyfind!(dependencies, name, 0)

--- a/lib/avrogen/schema/schema_registry.ex
+++ b/lib/avrogen/schema/schema_registry.ex
@@ -4,6 +4,8 @@ defmodule Avrogen.Schema.SchemaRegistry do
   schema name. Initialized on startup with schemas from priv directory.
   """
 
+  alias Avrogen.Util.Either
+
   use GenServer
 
   @ets_name "all"
@@ -38,7 +40,7 @@ defmodule Avrogen.Schema.SchemaRegistry do
       |> Jason.decode!()
     end)
     |> Avrogen.Schema.topological_sort()
-    |> Noether.Either.map(fn schemas ->
+    |> Either.map(fn schemas ->
       json = Jason.encode!(schemas)
       encoder = make_encoder(json)
       decoder = make_decoder(json)

--- a/lib/avrogen/util/either.ex
+++ b/lib/avrogen/util/either.ex
@@ -1,0 +1,12 @@
+defmodule Avrogen.Util.Either do
+  @moduledoc """
+  Fancy implementation of Either monad.
+  """
+
+  @type either :: {:ok, any()} | {:error, any()}
+  @type fun :: (any() -> any())
+
+  @spec map(either(), fun()) :: either()
+  def map({:ok, something}, function), do: {:ok, function.(something)}
+  def map({:error, something}, _function), do: {:error, something}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,6 @@ defmodule Avrogen.MixProject do
       {:excribe, "~> 0.1"},
       {:jason, "~> 1.0"},
       {:libgraph, "~> 0.16"},
-      {:noether, "~> 0.2"},
       {:timex, "~> 3.6"},
       {:typed_struct, "~> 0.3"},
       {:uniq, "~> 0.1"}

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,6 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.3.0", "d0cd9fc04b9061f82490f6581e0128379830e78535e017f7780f37fea7545726", [:rebar3], [], "hexpm", "a1e15a50d1887217de95f0b9b0793e32853f7c258a5cd227650889b38839fe9d"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "noether": {:hex, :noether, "0.3.0", "d6104b1a78c637a291a2dea0138239783952291f0d5c9a667b3524792b3f01b0", [:mix], [], "hexpm", "6e24fa22410cc7d92b81a5d791537a9cf565aa5b09fd40135d8a0e5cd5ceb2ab"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "snappyer": {:hex, :snappyer, "1.2.9", "9cc58470798648ce34c662ca0aa6daae31367667714c9a543384430a3586e5d3", [:rebar3], [], "hexpm", "18d00ca218ae613416e6eecafe1078db86342a66f86277bd45c95f05bf1c8b29"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},


### PR DESCRIPTION
Hello esteemed!

From the Claims domain, we're proposing this modification to remove the dependency from Noether.
I've replaced the few usages I found in the code (`Either.map`) with an equivalent function.

The reason behind that is that Noether is very used in the projects that are using this library, and it's very easy to get version conflict. Since it was very easy to replace all the usages of the Noether library I think it's worth to avoid all those conflicts in advance.

Thank you for your time <3