### PR TITLE
Fix drop_pii function for Date type

### DIFF
--- a/lib/avrogen/avro/types/logical/date.ex
+++ b/lib/avrogen/avro/types/logical/date.ex
@@ -59,7 +59,7 @@ defimpl CodeGenerator, for: Logical.Date do
 
   def drop_pii(%Logical.Date{}, function_name, _global) do
     quote do
-      def unquote(function_name)(%Date{}), do: Date.utc_now()
+      def unquote(function_name)(%Date{}), do: Date.utc_today()
     end
   end
 


### PR DESCRIPTION
Updating this because `Date.utc_now/0` doesn't actually exist