### PR TITLE
[ISSUE 31] in-line the old String.jaro_distance implementation

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,16 +14,17 @@ jobs:
     strategy:
       matrix:
         version: [
+          { elixir: '1.14', otp: '24' },
+          { elixir: '1.14', otp: '25' },
           { elixir: '1.15', otp: '24' },
           { elixir: '1.15', otp: '25' },
           { elixir: '1.15', otp: '26' },
           { elixir: '1.16', otp: '24' },
           { elixir: '1.16', otp: '25' },
-          { elixir: '1.16', otp: '26' },
-          { elixir: '1.17', otp: '26' },
-          { elixir: '1.17', otp: '27' },
-          { elixir: '1.18', otp: '26' },
-          { elixir: '1.18', otp: '27' }
+          { elixir: '1.16', otp: '26' }
+        #  { elixir: '1.17', otp: '25' },
+        #  { elixir: '1.17', otp: '26' },
+        #  { elixir: '1.17', otp: '27' }
         ]
     env:
       MIX_ENV: test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,17 +14,16 @@ jobs:
     strategy:
       matrix:
         version: [
-          { elixir: '1.14', otp: '24' },
-          { elixir: '1.14', otp: '25' },
           { elixir: '1.15', otp: '24' },
           { elixir: '1.15', otp: '25' },
           { elixir: '1.15', otp: '26' },
           { elixir: '1.16', otp: '24' },
           { elixir: '1.16', otp: '25' },
-          { elixir: '1.16', otp: '26' }
-        #  { elixir: '1.17', otp: '25' },
-        #  { elixir: '1.17', otp: '26' },
-        #  { elixir: '1.17', otp: '27' }
+          { elixir: '1.16', otp: '26' },
+          { elixir: '1.17', otp: '26' },
+          { elixir: '1.17', otp: '27' },
+          { elixir: '1.18', otp: '26' },
+          { elixir: '1.18', otp: '27' }
         ]
     env:
       MIX_ENV: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to
 
 
 [Unreleased]: https://github.com/primait/avrogen/compare/0.8.4...HEAD
-[0.8.3]: https://github.com/primait/avrogen/compare/0.8.3...0.8.4
+[0.8.4]: https://github.com/primait/avrogen/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/primait/avrogen/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/primait/avrogen/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/primait/avrogen/compare/0.8.0...0.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.8.4] - 2025-05-06
+
+### Fixed
+
+- In-line the old version of `String.jaro_distance/2`, since the one introduced in Elixir 1.17.1 changes the behaviour
+
+---
+
 ## [0.8.3] - 2025-04-11
 
 ### Fixed
@@ -79,7 +87,8 @@ and this project adheres to
   - `LocalTimestampMicros` (`long`).
 
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.8.3...HEAD
+[Unreleased]: https://github.com/primait/avrogen/compare/0.8.4...HEAD
+[0.8.3]: https://github.com/primait/avrogen/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/primait/avrogen/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/primait/avrogen/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/primait/avrogen/compare/0.8.0...0.8.1

--- a/lib/avrogen/util/fuzzy_enum_match.ex
+++ b/lib/avrogen/util/fuzzy_enum_match.ex
@@ -2,6 +2,9 @@ defmodule Avrogen.Util.FuzzyEnumMatch do
   @moduledoc """
   Fuzzy enum matching.
   """
+
+  alias Avrogen.Util.JaroDistance
+
   def preprocess(s) when is_binary(s) do
     normalised =
       s
@@ -45,7 +48,7 @@ defmodule Avrogen.Util.FuzzyEnumMatch do
     Enum.reduce(trigrams, MapSet.new(), fn trigram, candidates ->
       MapSet.union(candidates, Map.get(index, trigram, @empty))
     end)
-    |> Enum.map(fn {c, orig} -> {c, String.jaro_distance(canonical, c), orig} end)
+    |> Enum.map(fn {c, orig} -> {c, JaroDistance.jaro_distance(canonical, c), orig} end)
     |> Enum.sort_by(fn {_, similarity, _} -> similarity end, :desc)
   end
 

--- a/lib/avrogen/util/jaro_distance.ex
+++ b/lib/avrogen/util/jaro_distance.ex
@@ -1,0 +1,97 @@
+defmodule Avrogen.Util.JaroDistance do
+  @moduledoc """
+  This is the exact implementation of `String.jaro_distance/2` before Elixir 1.17.1 when it was
+  "fixed" for certain edge cases. Unfortunately, that fix broke a common case that we relied on
+  (see issue 31 for examples).
+  The simplest solution is just to keep using the old implementation. 
+  """
+
+  @spec jaro_distance(binary(), binary()) :: float()
+  def jaro_distance(string1, string2)
+
+  def jaro_distance(string, string), do: 1.0
+  def jaro_distance(_string, ""), do: 0.0
+  def jaro_distance("", _string), do: 0.0
+
+  def jaro_distance(string1, string2) when is_binary(string1) and is_binary(string2) do
+    {chars1, len1} = graphemes_and_length(string1)
+    {chars2, len2} = graphemes_and_length(string2)
+
+    case match(chars1, len1, chars2, len2) do
+      {0, _trans} ->
+        0.0
+
+      {comm, trans} ->
+        (comm / len1 + comm / len2 + (comm - trans) / comm) / 3
+    end
+  end
+
+  defp match(chars1, len1, chars2, len2) do
+    if len1 < len2 do
+      match(chars1, chars2, div(len2, 2) - 1)
+    else
+      match(chars2, chars1, div(len1, 2) - 1)
+    end
+  end
+
+  defp match(chars1, chars2, lim) do
+    match(chars1, chars2, {0, lim}, {0, 0, -1}, 0)
+  end
+
+  defp match([char | rest], chars, range, state, idx) do
+    {chars, state} = submatch(char, chars, range, state, idx)
+
+    case range do
+      {lim, lim} -> match(rest, tl(chars), range, state, idx + 1)
+      {pre, lim} -> match(rest, chars, {pre + 1, lim}, state, idx + 1)
+    end
+  end
+
+  defp match([], _, _, {comm, trans, _}, _), do: {comm, trans}
+
+  defp submatch(char, chars, {pre, _} = range, state, idx) do
+    case detect(char, chars, range) do
+      nil ->
+        {chars, state}
+
+      {subidx, chars} ->
+        {chars, proceed(state, idx - pre + subidx)}
+    end
+  end
+
+  defp detect(char, chars, {pre, lim}) do
+    detect(char, chars, pre + 1 + lim, 0, [])
+  end
+
+  defp detect(_char, _chars, 0, _idx, _acc), do: nil
+  defp detect(_char, [], _lim, _idx, _acc), do: nil
+
+  defp detect(char, [char | rest], _lim, idx, acc), do: {idx, Enum.reverse(acc, [nil | rest])}
+
+  defp detect(char, [other | rest], lim, idx, acc),
+    do: detect(char, rest, lim - 1, idx + 1, [other | acc])
+
+  defp proceed({comm, trans, former}, current) do
+    if current < former do
+      {comm + 1, trans + 1, current}
+    else
+      {comm + 1, trans, current}
+    end
+  end
+
+  defp graphemes_and_length(string),
+    do: graphemes_and_length(string, [], 0)
+
+  defp graphemes_and_length(string, acc, length) do
+    case :unicode_util.gc(string) do
+      [gc | rest] ->
+        graphemes_and_length(rest, [gc | acc], length + 1)
+
+      [] ->
+        {:lists.reverse(acc), length}
+
+      {:error, <<byte, rest::bits>>} ->
+        graphemes_and_length(rest, [<<byte>> | acc], length + 1)
+    end
+  end
+end

--- a/lib/avrogen/util/jaro_distance.ex
+++ b/lib/avrogen/util/jaro_distance.ex
@@ -1,9 +1,9 @@
 defmodule Avrogen.Util.JaroDistance do
   @moduledoc """
-  This is the exact implementation of `String.jaro_distance/2` before Elixir 1.17.1 when it was
+  This is Elixir's implementation of `String.jaro_distance/2` before Elixir 1.17.1 when it was
   "fixed" for certain edge cases. Unfortunately, that fix broke a common case that we relied on
   (see issue 31 for examples).
-  The simplest solution is just to keep using the old implementation. 
+  The simplest solution is just to keep using the old implementation.
   """
 
   @spec jaro_distance(binary(), binary()) :: float()

--- a/lib/avrogen/util/jaro_distance.ex
+++ b/lib/avrogen/util/jaro_distance.ex
@@ -1,6 +1,6 @@
 defmodule Avrogen.Util.JaroDistance do
   @moduledoc """
-  This is Elixir's implementation of `String.jaro_distance/2` before Elixir 1.17.1 when it was
+  This is Elixir's implementation of `String.jaro_distance/2` before Elixir 1.17.1, when it was
   "fixed" for certain edge cases. Unfortunately, that fix broke a common case that we relied on
   (see issue 31 for examples).
   The simplest solution is just to keep using the old implementation.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.8.3"
+  @version "0.8.4"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/test/util/jaro_distance_test.exs
+++ b/test/util/jaro_distance_test.exs
@@ -1,0 +1,31 @@
+defmodule Avrogen.Util.JaroDistance.Test do
+  use ExUnit.Case, async: true
+
+  test "jaro_distance/2" do
+    assert String.jaro_distance("same", "same") == 1.0
+    assert String.jaro_distance("any", "") == 0.0
+    assert String.jaro_distance("", "any") == 0.0
+    assert String.jaro_distance("martha", "marhta") == 0.9444444444444445
+    assert String.jaro_distance("martha", "marhha") == 0.888888888888889
+    assert String.jaro_distance("marhha", "martha") == 0.888888888888889
+    assert String.jaro_distance("dwayne", "duane") == 0.8222222222222223
+    assert String.jaro_distance("dixon", "dicksonx") == 0.7666666666666666
+    assert String.jaro_distance("xdicksonx", "dixon") == 0.7851851851851852
+    assert String.jaro_distance("shackleford", "shackelford") == 0.9696969696969697
+    assert String.jaro_distance("dunningham", "cunnigham") == 0.8962962962962964
+    assert String.jaro_distance("nichleson", "nichulson") == 0.9259259259259259
+    assert String.jaro_distance("jones", "johnson") == 0.7904761904761904
+    assert String.jaro_distance("massey", "massie") == 0.888888888888889
+    assert String.jaro_distance("abroms", "abrams") == 0.888888888888889
+    assert String.jaro_distance("hardin", "martinez") == 0.7222222222222222
+    assert String.jaro_distance("itman", "smith") == 0.4666666666666666
+    assert String.jaro_distance("jeraldine", "geraldine") == 0.9259259259259259
+    assert String.jaro_distance("michelle", "michael") == 0.8690476190476191
+    assert String.jaro_distance("julies", "julius") == 0.888888888888889
+    assert String.jaro_distance("tanya", "tonya") == 0.8666666666666667
+    assert String.jaro_distance("sean", "susan") == 0.7833333333333333
+    assert String.jaro_distance("jon", "john") == 0.9166666666666666
+    assert String.jaro_distance("jon", "jan") == 0.7777777777777777
+    assert String.jaro_distance("семена", "стремя") == 0.6666666666666666
+  end
+end

--- a/test/util/jaro_distance_test.exs
+++ b/test/util/jaro_distance_test.exs
@@ -1,31 +1,33 @@
 defmodule Avrogen.Util.JaroDistance.Test do
   use ExUnit.Case, async: true
 
+  alias Avrogen.Util.JaroDistance
+
   test "jaro_distance/2" do
-    assert String.jaro_distance("same", "same") == 1.0
-    assert String.jaro_distance("any", "") == 0.0
-    assert String.jaro_distance("", "any") == 0.0
-    assert String.jaro_distance("martha", "marhta") == 0.9444444444444445
-    assert String.jaro_distance("martha", "marhha") == 0.888888888888889
-    assert String.jaro_distance("marhha", "martha") == 0.888888888888889
-    assert String.jaro_distance("dwayne", "duane") == 0.8222222222222223
-    assert String.jaro_distance("dixon", "dicksonx") == 0.7666666666666666
-    assert String.jaro_distance("xdicksonx", "dixon") == 0.7851851851851852
-    assert String.jaro_distance("shackleford", "shackelford") == 0.9696969696969697
-    assert String.jaro_distance("dunningham", "cunnigham") == 0.8962962962962964
-    assert String.jaro_distance("nichleson", "nichulson") == 0.9259259259259259
-    assert String.jaro_distance("jones", "johnson") == 0.7904761904761904
-    assert String.jaro_distance("massey", "massie") == 0.888888888888889
-    assert String.jaro_distance("abroms", "abrams") == 0.888888888888889
-    assert String.jaro_distance("hardin", "martinez") == 0.7222222222222222
-    assert String.jaro_distance("itman", "smith") == 0.4666666666666666
-    assert String.jaro_distance("jeraldine", "geraldine") == 0.9259259259259259
-    assert String.jaro_distance("michelle", "michael") == 0.8690476190476191
-    assert String.jaro_distance("julies", "julius") == 0.888888888888889
-    assert String.jaro_distance("tanya", "tonya") == 0.8666666666666667
-    assert String.jaro_distance("sean", "susan") == 0.7833333333333333
-    assert String.jaro_distance("jon", "john") == 0.9166666666666666
-    assert String.jaro_distance("jon", "jan") == 0.7777777777777777
-    assert String.jaro_distance("семена", "стремя") == 0.6666666666666666
+    assert JaroDistance.jaro_distance("same", "same") == 1.0
+    assert JaroDistance.jaro_distance("any", "") == 0.0
+    assert JaroDistance.jaro_distance("", "any") == 0.0
+    assert JaroDistance.jaro_distance("martha", "marhta") == 0.9444444444444445
+    assert JaroDistance.jaro_distance("martha", "marhha") == 0.888888888888889
+    assert JaroDistance.jaro_distance("marhha", "martha") == 0.888888888888889
+    assert JaroDistance.jaro_distance("dwayne", "duane") == 0.8222222222222223
+    assert JaroDistance.jaro_distance("dixon", "dicksonx") == 0.7666666666666666
+    assert JaroDistance.jaro_distance("xdicksonx", "dixon") == 0.7851851851851852
+    assert JaroDistance.jaro_distance("shackleford", "shackelford") == 0.9696969696969697
+    assert JaroDistance.jaro_distance("dunningham", "cunnigham") == 0.8962962962962964
+    assert JaroDistance.jaro_distance("nichleson", "nichulson") == 0.9259259259259259
+    assert JaroDistance.jaro_distance("jones", "johnson") == 0.7904761904761904
+    assert JaroDistance.jaro_distance("massey", "massie") == 0.888888888888889
+    assert JaroDistance.jaro_distance("abroms", "abrams") == 0.888888888888889
+    assert JaroDistance.jaro_distance("hardin", "martinez") == 0.7222222222222222
+    assert JaroDistance.jaro_distance("itman", "smith") == 0.4666666666666666
+    assert JaroDistance.jaro_distance("jeraldine", "geraldine") == 0.9259259259259259
+    assert JaroDistance.jaro_distance("michelle", "michael") == 0.8690476190476191
+    assert JaroDistance.jaro_distance("julies", "julius") == 0.888888888888889
+    assert JaroDistance.jaro_distance("tanya", "tonya") == 0.8666666666666667
+    assert JaroDistance.jaro_distance("sean", "susan") == 0.7833333333333333
+    assert JaroDistance.jaro_distance("jon", "john") == 0.9166666666666666
+    assert JaroDistance.jaro_distance("jon", "jan") == 0.7777777777777777
+    assert JaroDistance.jaro_distance("семена", "стремя") == 0.6666666666666666
   end
 end

--- a/test/util/jaro_distance_test.exs
+++ b/test/util/jaro_distance_test.exs
@@ -29,5 +29,7 @@ defmodule Avrogen.Util.JaroDistance.Test do
     assert JaroDistance.jaro_distance("jon", "john") == 0.9166666666666666
     assert JaroDistance.jaro_distance("jon", "jan") == 0.7777777777777777
     assert JaroDistance.jaro_distance("семена", "стремя") == 0.6666666666666666
+    # differs from String.jaro_distance/2 after Elixir 1.17.1 in this case:
+    assert JaroDistance.jaro_distance("__barstaff_", "__bar_staff_") == 0.9419191919191919
   end
 end


### PR DESCRIPTION
Solves https://github.com/primait/avrogen/issues/31 by copying the version of `String.jaro_distance/2` used by Elixir 1.16. This stops us using the one introduced in 1.17.1, which sometimes produces worse results. We won't be able to update our clients to use Elixir 1.17.1 or above until this is resolved (we're currently on 1.16.3 and looking to upgrade).

This is the easiest solution and means we don't have to rewrite the fuzzy matching algorithm, which would require extensive testing.