### PR TITLE
feat: Support big-decimal as well as big_decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.9.0] - 2025-10-22
+
+### Added
+
+- Support for the `bytes`-backed `big-decimal` scalable precision decimal type added in v1.12.0. The non-standard, `string`-backed [`big_decimal`](lib/avrogen/avro/types/logical/decimal_string.ex) is still supported and now also accepts `big-decimal` as the logical type name.
+
+---
+
 ## [0.8.6] - 2025-08-25
 
 ### Fixed
@@ -102,7 +110,8 @@ and this project adheres to
   - `LocalTimestampMillis` (`long`).
   - `LocalTimestampMicros` (`long`).
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.8.6...HEAD
+[Unreleased]: https://github.com/primait/avrogen/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/primait/avrogen/compare/0.8.6...0.9.0
 [0.8.6]: https://github.com/primait/avrogen/compare/0.8.5...0.8.6
 [0.8.5]: https://github.com/primait/avrogen/compare/0.8.4...0.8.5
 [0.8.4]: https://github.com/primait/avrogen/compare/0.8.3...0.8.4

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The following logical types are also supported:
 | ------------------------ | -------------------- | --------------- |
 | `uuid`                   | `string`             | `String`        |
 | `big_decimal`            | `string`             | `Decimal`       |
+| `big-decimal`            | `string`             | `Decimal`       |
 | `decimal`                | `string`             | `Decimal`       |
 | `decimal`                | `bytes`              | `Decimal`       |
 | `date`                   | `int`                | `Date`          |
@@ -391,7 +392,7 @@ The various types produce random values according to the following rules:
 | `null`                                        | Always produces `nil`.                                                                                              |
 | `union`                                       | Random instance of any of the types within the union, where each type is equally likely to be chosen.               |
 | `string`                                      | Random utf8 binary of up to 1000 codepoints, where each codepoint lies in the range `0 <= codepoint < 10,000`.      |
-| `int`, `double`, `big_decimal` (logical type) | Random value in the range `-2,147,483,648 <= value < 2,147,483,648`.                                                |
+| `int`, `double`, `big_decimal`, `big-decimal` (logical type) | Random value in the range `-2,147,483,648 <= value < 2,147,483,648`.                                                |
 | `iso_date` and `iso_datetime` (logical types) | Random value in the range `1970-01-01T00:00:00 <= value < 2045-01-01T00:00:00`.                                     |
 | `enum`                                        | One of the symbols selected at random, with each symbol having an equal probability of showing up.                  |
 | `array`                                       | Random list of up to 10 elements, where the value of each element is a random instance of the array's element type. |

--- a/README.md
+++ b/README.md
@@ -286,10 +286,9 @@ The following logical types are also supported:
 | AVRO Logical Type        | AVRO Underlying Type | Elixir Type     |
 | ------------------------ | -------------------- | --------------- |
 | `uuid`                   | `string`             | `String`        |
-| `big_decimal`            | `string`             | `Decimal`       |
-| `big-decimal`            | `string`             | `Decimal`       |
 | `decimal`                | `string`             | `Decimal`       |
 | `decimal`                | `bytes`              | `Decimal`       |
+| `big-decimal`            | `bytes`              | `Decimal`       |
 | `date`                   | `int`                | `Date`          |
 | `date`                   | `string`             | `Date`          |
 | `iso_date`               | `string`             | `Date`          |
@@ -392,7 +391,7 @@ The various types produce random values according to the following rules:
 | `null`                                        | Always produces `nil`.                                                                                              |
 | `union`                                       | Random instance of any of the types within the union, where each type is equally likely to be chosen.               |
 | `string`                                      | Random utf8 binary of up to 1000 codepoints, where each codepoint lies in the range `0 <= codepoint < 10,000`.      |
-| `int`, `double`, `big_decimal`, `big-decimal` (logical type) | Random value in the range `-2,147,483,648 <= value < 2,147,483,648`.                                                |
+| `int`, `double`, `big-decimal` (logical type) | Random value in the range `-2,147,483,648 <= value < 2,147,483,648`.                                                |
 | `iso_date` and `iso_datetime` (logical types) | Random value in the range `1970-01-01T00:00:00 <= value < 2045-01-01T00:00:00`.                                     |
 | `enum`                                        | One of the symbols selected at random, with each symbol having an equal probability of showing up.                  |
 | `array`                                       | Random list of up to 10 elements, where the value of each element is a random instance of the array's element type. |

--- a/lib/avrogen/avro/types/logical.ex
+++ b/lib/avrogen/avro/types/logical.ex
@@ -41,6 +41,7 @@ defmodule Avrogen.Avro.Types.Logical do
   def module(%{"logicalType" => "decimal", "type" => "bytes"}), do: __MODULE__.Decimal
   def module(%{"logicalType" => "big_decimal", "type" => "string"}), do: __MODULE__.DecimalString
   def module(%{"logicalType" => "big-decimal", "type" => "string"}), do: __MODULE__.DecimalString
+  def module(%{"logicalType" => "big-decimal", "type" => "bytes"}), do: __MODULE__.BigDecimal
 
   def module(%{"logicalType" => "uuid", "type" => "string"}), do: __MODULE__.UUID
 

--- a/lib/avrogen/avro/types/logical.ex
+++ b/lib/avrogen/avro/types/logical.ex
@@ -40,6 +40,7 @@ defmodule Avrogen.Avro.Types.Logical do
   def module(%{"logicalType" => "decimal", "type" => "string"}), do: __MODULE__.DecimalString
   def module(%{"logicalType" => "decimal", "type" => "bytes"}), do: __MODULE__.Decimal
   def module(%{"logicalType" => "big_decimal", "type" => "string"}), do: __MODULE__.DecimalString
+  def module(%{"logicalType" => "big-decimal", "type" => "string"}), do: __MODULE__.DecimalString
 
   def module(%{"logicalType" => "uuid", "type" => "string"}), do: __MODULE__.UUID
 

--- a/lib/avrogen/avro/types/logical/big_decimal.ex
+++ b/lib/avrogen/avro/types/logical/big_decimal.ex
@@ -1,0 +1,83 @@
+defmodule Avrogen.Avro.Types.Logical.BigDecimal do
+  @moduledoc """
+    This represents the logical type of the scalable precision [decimal](https://avro.apache.org/docs/1.12.0/specification/#decimal)
+    introduced in version 1.12.0
+
+    Like the fixed precision decimal logical type, it represents an arbitrary-precision signed decimal number of
+    the form unscaled × 10-scale. However, the scale and precision do not need to be known in advance.
+
+    To quote the docs:
+
+    > Here, as scale property is stored in value itself it needs more bytes than preceding decimal type, but it allows more flexibility.
+  """
+
+  @logical_type "big-decimal"
+  @avro_type "bytes"
+
+  use TypedStruct
+
+  @derive Jason.Encoder
+  typedstruct do
+    # This will always be set to @logical_type it is maintained to simplify
+    # the JSON encoding logic.
+    field :logicalType, String.t()
+    # This will always be set to @avro_type it is maintained to simplify the JSON encoding logic.
+    field :type, String.t()
+  end
+
+  def parse(%{"logicalType" => @logical_type, "type" => @avro_type}) do
+    %__MODULE__{
+      type: @avro_type,
+      logicalType: @logical_type
+    }
+  end
+end
+
+alias Avrogen.Avro.Types.Logical.BigDecimal
+alias Avrogen.Avro.Schema.CodeGenerator
+
+defimpl CodeGenerator, for: BigDecimal do
+  def external_dependencies(_), do: []
+
+  def normalize(value, global, _parent_namespace, _scope_embedded_types), do: {value, global}
+
+  def elixir_type(%BigDecimal{}), do: quote(do: Decimal.t())
+
+  def encode_function(%BigDecimal{}, function_name, _global) do
+    quote do
+      defp unquote(function_name)(%Decimal{} = decimal), do: Decimal.to_string(decimal)
+    end
+  end
+
+  def decode_function(%BigDecimal{}, function_name, _global) do
+    quote do
+      defp unquote(function_name)(decimal) when is_binary(decimal) do
+        case Decimal.parse(decimal) do
+          {decimal, _} -> {:ok, decimal}
+          :error -> {:error, "Not a decimal"}
+        end
+      end
+    end
+  end
+
+  def contains_pii?(%BigDecimal{}, _global), do: false
+
+  def drop_pii(%BigDecimal{}, function_name, _global) do
+    quote do
+      def unquote(function_name)(%Decimal{}), do: Decimal.new("0")
+    end
+  end
+
+  def random_instance(
+        %BigDecimal{logicalType: logicalType},
+        range_opts,
+        _global
+      ) do
+    range_opts
+    |> Keyword.get(String.to_atom(logicalType), [])
+    |> case do
+      [] -> quote(do: Constructors.decimal())
+      opts -> quote(do: Constructors.decimal(unquote(opts)))
+    end
+  end
+end

--- a/lib/avrogen/avro/types/logical/decimal_string.ex
+++ b/lib/avrogen/avro/types/logical/decimal_string.ex
@@ -8,7 +8,7 @@ defmodule Avrogen.Avro.Types.Logical.DecimalString do
 
   use TypedStruct
 
-  @logical_types ["decimal", "big_decimal"]
+  @logical_types ["decimal", "big_decimal", "big-decimal"]
   @avro_type "string"
 
   @derive Jason.Encoder

--- a/test/code_generator_test.exs
+++ b/test/code_generator_test.exs
@@ -471,7 +471,7 @@ defmodule Avrogen.CodeGenerator.Test do
                |> Macro.to_string()
     end
 
-    test "elixir type: 'big decimal logical type' standard, annotates string" do
+    test "elixir type: 'big decimal logical type' non-standard, with hyphen, annotates string" do
       assert "Decimal.t()" ==
                %{"type" => "string", "logicalType" => "big-decimal"}
                |> Schema.parse()

--- a/test/code_generator_test.exs
+++ b/test/code_generator_test.exs
@@ -463,6 +463,30 @@ defmodule Avrogen.CodeGenerator.Test do
                |> Macro.to_string()
     end
 
+    test "elixir type: 'big decimal logical type'" do
+      assert "Decimal.t()" ==
+               %{"type" => "bytes", "logicalType" => "big-decimal"}
+               |> Schema.parse()
+               |> CodeGenerator.elixir_type()
+               |> Macro.to_string()
+    end
+
+    test "elixir type: 'big decimal logical type' standard, annotates string" do
+      assert "Decimal.t()" ==
+               %{"type" => "string", "logicalType" => "big-decimal"}
+               |> Schema.parse()
+               |> CodeGenerator.elixir_type()
+               |> Macro.to_string()
+    end
+
+    test "elixir type: 'big decimal logical type' non-standard, with underscore, annotates string" do
+      assert "Decimal.t()" ==
+               %{"type" => "string", "logicalType" => "big_decimal"}
+               |> Schema.parse()
+               |> CodeGenerator.elixir_type()
+               |> Macro.to_string()
+    end
+
     test "elixir type: [null, 'iso_date logical type']" do
       assert "nil | Date.t()" ==
                ["null", %{"type" => "string", "logicalType" => "iso_date"}]


### PR DESCRIPTION
The spec has `big-decimal`, see: https://avro.apache.org/docs/++version++/specification/#decimal.

I believe that this PR will add support for `big-decimal` while maintaining backwards compatibility for `big_decimal`.