### PR TITLE
[PMPOSU-777]: [avrogen] feat: Handle references to previous defined schema in top-level record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+---
+
+## [0.10.0] - 2025-11-07
+
 ### Fixed
 
 - Fix issue where `Avrogen.Schema.external_dependencies` was wrongly identifying references to previously defined types as external dependencies.
@@ -114,7 +118,9 @@ and this project adheres to
   - `LocalTimestampMillis` (`long`).
   - `LocalTimestampMicros` (`long`).
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.9.0...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/primait/avrogen/compare/0.10.0...0.10.0
 [0.9.0]: https://github.com/primait/avrogen/compare/0.8.6...0.9.0
 [0.8.6]: https://github.com/primait/avrogen/compare/0.8.5...0.8.6
 [0.8.5]: https://github.com/primait/avrogen/compare/0.8.4...0.8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix issue where `Avrogen.Schema.external_dependencies` was wrongly identifying references to previously defined types as external dependencies.
+
 ---
 
 ## [0.9.0] - 2025-10-22

--- a/lib/avrogen/schema.ex
+++ b/lib/avrogen/schema.ex
@@ -12,19 +12,78 @@ defmodule Avrogen.Schema do
   Get a list of external types referenced in a given record/enum.
   """
   @spec external_dependencies(schema()) :: [String.t()]
-  def external_dependencies(%{"type" => "record", "fields" => fields}) do
-    fields
-    |> Enum.flat_map(fn
-      %{"type" => types} when is_list(types) ->
-        Enum.flat_map(types, fn type -> Avrogen.Types.external_dependencies(type) end)
+  def external_dependencies(%{"namespace" => namespace, "type" => "record", "fields" => fields}) do
+    {external_dependencies, _previously_defined_types} =
+      fields
+      |> Enum.flat_map_reduce(
+        MapSet.new(),
+        fn field, previously_defined_types ->
+          handle_field(field, previously_defined_types, namespace)
+        end
+      )
 
-      %{"type" => type} ->
-        Avrogen.Types.external_dependencies(type)
-    end)
+    external_dependencies |> MapSet.new() |> MapSet.to_list()
+  end
+
+  def external_dependencies(%{"type" => "record", "fields" => fields}) do
+    {external_dependencies, _previously_defined_types} =
+      fields
+      |> Enum.flat_map_reduce(
+        MapSet.new(),
+        fn field, previously_defined_types ->
+          handle_field(field, previously_defined_types, nil)
+        end
+      )
+
+    external_dependencies |> MapSet.new() |> MapSet.to_list()
   end
 
   def external_dependencies(_) do
     []
+  end
+
+  # When the type of the field is a Union, we exclude the previously defined
+  # types and check if those that remain are primitives.
+  @spec handle_field(map(), MapSet.t(String.t()), String.t() | nil) ::
+          {[String.t()], MapSet.t(String.t())}
+  defp handle_field(%{"type" => types}, previously_defined_types, _namespace)
+       when is_list(types) do
+    external_dependencies =
+      types
+      |> MapSet.new()
+      |> MapSet.difference(previously_defined_types)
+      |> Enum.flat_map(&Avrogen.Types.external_dependencies/1)
+
+    {external_dependencies, previously_defined_types}
+  end
+
+  # When the type of the field is a named type, we add it to our set of
+  # previously defined types.
+  defp handle_field(%{"type" => %{"name" => name}}, previously_defined_types, namespace) do
+    fully_qualified_name =
+      if namespace do
+        fqn(%{name: name, namespace: namespace})
+      else
+        fqn(%{name: name})
+      end
+
+    updated_previously_defined_types =
+      MapSet.put(previously_defined_types, fully_qualified_name)
+
+    {[], updated_previously_defined_types}
+  end
+
+  # Otherwise, we check whether this type has been defined previously and, if
+  # not, we check if it's a primitive.
+  defp handle_field(%{"type" => type}, previously_defined_types, _namespace) do
+    external_dependencies =
+      if type in previously_defined_types do
+        []
+      else
+        Avrogen.Types.external_dependencies(type)
+      end
+
+    {external_dependencies, previously_defined_types}
   end
 
   @doc """

--- a/lib/avrogen/schema.ex
+++ b/lib/avrogen/schema.ex
@@ -67,8 +67,7 @@ defmodule Avrogen.Schema do
         fqn(%{name: name})
       end
 
-    updated_previously_defined_types =
-      MapSet.put(previously_defined_types, fully_qualified_name)
+    updated_previously_defined_types = MapSet.put(previously_defined_types, fully_qualified_name)
 
     {[], updated_previously_defined_types}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.10.0"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -23,6 +23,75 @@ defmodule Avrogen.Schema.Test do
 
       assert Avrogen.Schema.external_dependencies(input) == []
     end
+
+    test "doesn't identify previously defined types as external dependencies (with namespace)" do
+      input = %{
+        "namespace" => "internal",
+        "type" => "record",
+        "fields" => [
+          %{
+            "name" => "foo1",
+            "type" => %{
+              "name" => "Foo",
+              "type" => "enum",
+              "symbols" => ["A", "B"]
+            }
+          },
+          %{
+            "name" => "foo2",
+            "type" => "internal.Foo"
+          },
+          %{
+            "name" => "foo3",
+            "type" => ["null", "internal.Foo"]
+          },
+          %{
+            "name" => "bar1",
+            "type" => "external.Bar"
+          },
+          %{
+            "name" => "bar2",
+            "type" => ["null", "external.Bar"]
+          }
+        ]
+      }
+
+      assert Avrogen.Schema.external_dependencies(input) == ["external.Bar"]
+    end
+
+    test "doesn't identify previously defined types as external dependencies (without namespace)" do
+      input = %{
+        "type" => "record",
+        "fields" => [
+          %{
+            "name" => "foo1",
+            "type" => %{
+              "name" => "Foo",
+              "type" => "enum",
+              "symbols" => ["A", "B"]
+            }
+          },
+          %{
+            "name" => "foo2",
+            "type" => "Foo"
+          },
+          %{
+            "name" => "foo3",
+            "type" => ["null", "Foo"]
+          },
+          %{
+            "name" => "bar1",
+            "type" => "Bar"
+          },
+          %{
+            "name" => "bar2",
+            "type" => ["null", "Bar"]
+          }
+        ]
+      }
+
+      assert Avrogen.Schema.external_dependencies(input) == ["Bar"]
+    end
   end
 
   describe "fqn" do


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PMPOSU-777

This pull request fixes a bug in the `Avrogen.Schema.external_dependencies` function, ensuring that previously defined types within a schema are no longer incorrectly identified as external dependencies. The changes include refactoring the implementation to properly track defined types, updating tests to cover these cases, and bumping the package version.

### Bug fix and implementation improvements

* Refactored the `external_dependencies` function in `lib/avrogen/schema.ex` to track previously defined types and exclude them from external dependencies. This includes introducing the `handle_field` helper and correctly handling unions and named types.

### Testing enhancements

* Added new test cases in `test/schema_test.exs` to verify that previously defined types (with and without namespace) are not identified as external dependencies.

### Documentation and release

* Updated the `CHANGELOG.md` to document the bug fix for external dependencies detection.
* Bumped the version in `mix.exs` from `0.9.0` to `0.10.0` to reflect the new release.
