### PR TITLE
Support backwards compatibility in from_avro_map/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.11.0] - 2026-02-02
+
+### Changed
+
+- Enhanced `from_avro_map/1` to support backwards compatibility when schemas evolve. Nullable fields are no longer matched in the function signature, allowing newer versions of modules to successfully decode payloads encoded with older schema versions that don't include newly added nullable fields.
+
+---
+
 ## [0.10.0] - 2025-11-07
 
 ### Fixed
@@ -118,8 +126,8 @@ and this project adheres to
   - `LocalTimestampMillis` (`long`).
   - `LocalTimestampMicros` (`long`).
 
-
-[Unreleased]: https://github.com/primait/avrogen/compare/0.10.0...HEAD
+[Unreleased]: https://github.com/primait/avrogen/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/primait/avrogen/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/primait/avrogen/compare/0.10.0...0.10.0
 [0.9.0]: https://github.com/primait/avrogen/compare/0.8.6...0.9.0
 [0.8.6]: https://github.com/primait/avrogen/compare/0.8.5...0.8.6

--- a/lib/avrogen/avro/types/record.ex
+++ b/lib/avrogen/avro/types/record.ex
@@ -73,18 +73,7 @@ defmodule Avrogen.Avro.Types.Record do
         unquote(to_avro_map(record))
 
         @impl true
-        unquote(from_avro_map(record))
-
-        @required_keys MapSet.new(unquote(required_keys(record)))
-        def from_avro_map(%{} = invalid) do
-          actual = Map.keys(invalid) |> MapSet.new()
-          missing = MapSet.difference(@required_keys, actual) |> Enum.join(", ")
-          {:error, "Missing keys: " <> missing}
-        end
-
-        def from_avro_map(_) do
-          {:error, "Expected a map."}
-        end
+        unquote_splicing(from_avro_map(record))
 
         @pii_fields MapSet.new(unquote(pii_keys(record)))
         def pii_fields, do: @pii_fields
@@ -118,36 +107,98 @@ defmodule Avrogen.Avro.Types.Record do
     end
   end
 
-  defp from_avro_map(%__MODULE__{fields: fields}) do
-    name =
+  @doc false
+  # Generates the `from_avro_map/1` function clauses for decoding Avro maps into structs.
+  #
+  # This function generates up to three function clauses:
+  # 1. The main clause that pattern matches on required fields and decodes the map
+  # 2. A clause that handles missing required keys (only if the record has required fields)
+  # 3. A catch-all clause that returns an error when a non-map is passed (only if there are required fields)
+  defp from_avro_map(%__MODULE__{} = record) do
+    [
+      from_avro_map_main_clause(record),
+      from_avro_map_missing_keys_clause(record),
+      from_avro_map_catch_all_clause()
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> MacroUtils.flatten_block()
+  end
+
+  # Generates the main `from_avro_map/1` clause that pattern matches on required fields
+  # and decodes the Avro map into a struct, handling optional and default fields.
+  defp from_avro_map_main_clause(%__MODULE__{fields: fields}) do
+    # Choose the variable name for the map parameter in the function signature.
+    # If all fields are required, use "_avro_map" (underscore prefix) because the map
+    # is only used for pattern matching and not referenced in the function body.
+    # If there are optional/default fields, use "avro_map" (no underscore) because
+    # we'll need to access the map to extract those fields.
+    map_var_name =
       fields
-      |> Enum.any?(&Field.has_default?/1)
+      |> Enum.all?(&Field.is_required?/1)
       |> case do
-        true -> "avro_map"
-        false -> "_avro_map"
+        true -> "_avro_map"
+        false -> "avro_map"
       end
       |> Code.string_to_quoted!()
 
-    required_fields =
+    # Build pattern bindings for required fields that will be matched in the function signature
+    # e.g., %{"id" => id, "name" => name}
+    pattern_bindings =
       fields
-      |> Enum.reject(&Field.has_default?/1)
+      |> Enum.filter(&Field.is_required?/1)
       |> Enum.map(fn field -> {field.name, Code.string_to_quoted!(field.name)} end)
 
-    optional_fields =
-      fields
-      |> Enum.filter(&Field.has_default?/1)
-      |> Enum.map(&Field.bind_with_default/1)
+    # Build variable bindings for optional/default fields that will be set in the function body
+    # These fields are extracted from the map with their default values if not present
+    body_bindings =
+      Enum.flat_map(fields, fn field ->
+        if Field.is_required?(field) do
+          []
+        else
+          [Field.bind_with_default(field, map_var_name)]
+        end
+      end)
 
+    # Build the struct field assignments, applying decode functions to each field value
     record_fields =
       Enum.map(fields, fn field ->
         {String.to_atom(field.name), __MODULE__.Field.from_avro_map_clause(field)}
       end)
 
     quote do
-      def from_avro_map(%{unquote_splicing(required_fields)} = unquote(name)) do
-        unquote_splicing(optional_fields)
+      def from_avro_map(%{unquote_splicing(pattern_bindings)} = unquote(map_var_name)) do
+        unquote_splicing(body_bindings)
 
         {:ok, %__MODULE__{unquote_splicing(record_fields)}}
+      end
+    end
+  end
+
+  # Generates a `from_avro_map/1` clause that returns an error when required keys are missing.
+  # Returns `nil` if the record has no required fields (clause not needed).
+  defp from_avro_map_missing_keys_clause(record) do
+    req_keys = required_keys(record)
+
+    if Enum.empty?(req_keys) do
+      nil
+    else
+      quote do
+        @required_keys MapSet.new(unquote(req_keys))
+        def from_avro_map(%{} = invalid) do
+          actual = Map.keys(invalid) |> MapSet.new()
+          missing = MapSet.difference(@required_keys, actual) |> Enum.join(", ")
+          {:error, "Missing keys: " <> missing}
+        end
+      end
+    end
+  end
+
+  # Generates a catch-all `from_avro_map/1` clause that returns an error when a non-map is passed.
+  # Only generated when the record has required fields, as it would be unreachable otherwise.
+  defp from_avro_map_catch_all_clause do
+    quote do
+      def from_avro_map(_) do
+        {:error, "Expected a map."}
       end
     end
   end
@@ -173,7 +224,7 @@ defmodule Avrogen.Avro.Types.Record do
 
   defp required_keys(%__MODULE__{fields: fields}) do
     fields
-    |> Enum.reject(&Field.has_default?/1)
+    |> Enum.filter(&Field.is_required?/1)
     |> Enum.map(&Field.name/1)
   end
 

--- a/lib/avrogen/avro/types/record/field.ex
+++ b/lib/avrogen/avro/types/record/field.ex
@@ -60,6 +60,13 @@ defmodule Avrogen.Avro.Types.Record.Field do
   def has_default?(%__MODULE__{default: nil}), do: false
   def has_default?(%__MODULE__{}), do: true
 
+  def is_nullable?(%__MODULE__{type: %Avrogen.Avro.Types.Union{types: types}}),
+    do: Enum.any?(types, &(&1 == Types.Primitive.null()))
+
+  def is_nullable?(%__MODULE__{}), do: false
+
+  def is_required?(%__MODULE__{} = field), do: not has_default?(field) and not is_nullable?(field)
+
   def is_pii?(%__MODULE__{pii: pii}), do: pii
 
   def range_opts(%__MODULE__{range: nil}), do: []
@@ -73,15 +80,15 @@ defmodule Avrogen.Avro.Types.Record.Field do
 
   def to_keywords(val), do: val
 
-  def bind_with_default(%__MODULE__{name: name, default: default}) do
+  def bind_with_default(%__MODULE__{name: name, default: default}, map_var) do
     variable_name = Code.string_to_quoted!(name)
 
     case default do
       default when is_nil(default) or default == "null" ->
-        quote(do: unquote(variable_name) = avro_map[unquote(name)])
+        quote(do: unquote(variable_name) = unquote(map_var)[unquote(name)])
 
       default ->
-        quote(do: unquote(variable_name) = avro_map[unquote(name)] || unquote(default))
+        quote(do: unquote(variable_name) = unquote(map_var)[unquote(name)] || unquote(default))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Avrogen.MixProject do
       aliases: aliases(),
       deps: deps(),
       docs: docs(),
-      dialyzer: [plt_add_apps: [:mix]]
+      dialyzer: [plt_add_apps: [:mix]],
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -77,4 +78,8 @@ defmodule Avrogen.MixProject do
       extras: ["README.md"]
     ]
   end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.11.0"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/test/enum_with_default_test.exs
+++ b/test/enum_with_default_test.exs
@@ -4,7 +4,7 @@ defmodule Avrogen.EnumWithDefaultTest do
   """
   use ExUnit.Case, async: false
 
-  alias Avrogen.Avro.Schema
+  alias Avrogen.Test.SchemaHelpers
   alias Avrogen.Schema.SchemaRegistry
 
   @schemas_dir "test/enum_default_schemas"
@@ -20,8 +20,8 @@ defmodule Avrogen.EnumWithDefaultTest do
     schema_1 = File.read!(Path.join(@schemas_dir, "RecordWithEnumDefault1.avsc"))
     schema_2 = File.read!(Path.join(@schemas_dir, "RecordWithEnumDefault2.avsc"))
 
-    module_1 = generate_module_from_schema(schema_1)
-    module_2 = generate_module_from_schema(schema_2)
+    module_1 = SchemaHelpers.generate_module_from_schema(schema_1)
+    module_2 = SchemaHelpers.generate_module_from_schema(schema_2)
 
     encoder = SchemaRegistry.make_encoder(schema_2)
     decoder = SchemaRegistry.make_decoder(schema_1)
@@ -36,31 +36,5 @@ defmodule Avrogen.EnumWithDefaultTest do
 
     assert {:ok, %^module_1{source: :unknown}} =
              decoder.(module_1.avro_fqn(), encoded) |> module_1.from_avro_map()
-  end
-
-  defp generate_module_from_schema(schema) do
-    schema
-    |> generate_code()
-    |> Enum.map(&compile_code/1)
-    |> Enum.map(&module_name/1)
-    |> Enum.reject(&is_nil/1)
-    |> List.first()
-  end
-
-  # Gets the module name of the record type generated code
-  defp module_name([_, {mod_name, _}]), do: mod_name
-  defp module_name(_), do: nil
-
-  defp compile_code(code) do
-    code
-    |> IO.iodata_to_binary()
-    |> Code.compile_string()
-  end
-
-  defp generate_code(schema) do
-    schema
-    |> Jason.decode!()
-    |> Schema.generate_code([], "Test")
-    |> Enum.map(&elem(&1, 1))
   end
 end

--- a/test/enum_with_default_test.exs
+++ b/test/enum_with_default_test.exs
@@ -4,8 +4,8 @@ defmodule Avrogen.EnumWithDefaultTest do
   """
   use ExUnit.Case, async: false
 
-  alias Avrogen.Test.SchemaHelpers
   alias Avrogen.Schema.SchemaRegistry
+  alias Avrogen.Test.SchemaHelpers
 
   @schemas_dir "test/enum_default_schemas"
 

--- a/test/from_avro_map_schemas/TestRecord.avsc
+++ b/test/from_avro_map_schemas/TestRecord.avsc
@@ -1,0 +1,23 @@
+{
+    "type": "record",
+    "name": "TestRecord",
+    "namespace": "from_avro_map_schemas",
+    "fields": [
+        {
+            "name": "opt_string",
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        {
+            "name": "required_string",
+            "type": "string"
+        },
+        {
+            "name": "string_with_default",
+            "type": "string",
+            "default": "default_value"
+        }
+    ]
+}

--- a/test/from_avro_map_test.exs
+++ b/test/from_avro_map_test.exs
@@ -1,0 +1,56 @@
+defmodule Avrogen.FromAvroMapTest do
+  @moduledoc """
+  Tests enum default value behavior during schema evolution.
+  """
+  use ExUnit.Case, async: false
+
+  alias Avrogen.Test.SchemaHelpers
+
+  @schemas_dir "test/from_avro_map_schemas"
+  setup_all do
+    # Shut up warnings
+    Code.put_compiler_option(:ignore_already_consolidated, true)
+    Code.put_compiler_option(:ignore_module_conflict, true)
+    Code.put_compiler_option(:no_warn_undefined, :all)
+
+    :ok
+  end
+
+  describe "from_avro_map/1" do
+    setup do
+      schema = File.read!(Path.join(@schemas_dir, "TestRecord.avsc"))
+
+      module = SchemaHelpers.generate_module_from_schema(schema)
+
+      {:ok, module: module}
+    end
+
+    test "returns error when required keys are not present", %{module: module} do
+      assert {:error, "Missing keys: required_string"} = module.from_avro_map(%{})
+    end
+
+    test "decodes optional and default fields correctly when only required fields are provided",
+         %{module: module} do
+      assert {:ok,
+              %^module{
+                required_string: "value",
+                opt_string: nil,
+                string_with_default: "default_value"
+              }} = module.from_avro_map(%{"required_string" => "value"})
+    end
+
+    test "decodes all fields correctly when all fields are provided", %{module: module} do
+      assert {:ok,
+              %^module{
+                required_string: "required_value",
+                opt_string: "optional_value",
+                string_with_default: "custom_value"
+              }} =
+               module.from_avro_map(%{
+                 "required_string" => "required_value",
+                 "opt_string" => "optional_value",
+                 "string_with_default" => "custom_value"
+               })
+    end
+  end
+end

--- a/test/support/schema_helpers.ex
+++ b/test/support/schema_helpers.ex
@@ -1,0 +1,38 @@
+defmodule Avrogen.Test.SchemaHelpers do
+  @moduledoc """
+  Common helper functions for testing schema generation and module compilation.
+  """
+
+  alias Avrogen.Avro.Schema
+
+  @doc """
+  Generates a module from an Avro schema string.
+
+  The schema is parsed, code is generated, compiled, and the resulting module name is returned.
+  """
+  def generate_module_from_schema(schema) do
+    schema
+    |> generate_code()
+    |> Enum.map(&compile_code/1)
+    |> Enum.map(&module_name/1)
+    |> Enum.reject(&is_nil/1)
+    |> List.first()
+  end
+
+  # Gets the module name of the record type generated code
+  defp module_name([_, {mod_name, _}]), do: mod_name
+  defp module_name(_), do: nil
+
+  defp compile_code(code) do
+    code
+    |> IO.iodata_to_binary()
+    |> Code.compile_string()
+  end
+
+  defp generate_code(schema) do
+    schema
+    |> Jason.decode!()
+    |> Schema.generate_code([], "Test")
+    |> Enum.map(&elem(&1, 1))
+  end
+end


### PR DESCRIPTION
The goal of this PR is to allow Avrogen-generated modules to be backwards compatible.

The problem with the current implementation is that, if a schema is evolved in a backwards-compatible way (e.g. a new nullable field is added), the `from_avro_map/1` function generated from the new schema won't be able to decode payloads encoded with the old version of the schema. This happens because old payloads won't have the new nullable field, but `from_avro_map/1` is pattern matching all the map fields.

With this PR, nullable fields are not matched in the function signature. This way, newer versions of modules can read payloads encoded with older versions.