### PR TITLE
Fix compilation warnings on generated files

### DIFF
--- a/lib/avrogen/avro/types/map.ex
+++ b/lib/avrogen/avro/types/map.ex
@@ -65,13 +65,13 @@ defimpl CodeGenerator, for: Map do
       |> MacroUtils.flatten_block()
 
     quote do
-      unquote(inner)
-
       defp unquote(function_name)(map) when is_map(map) do
         Enum.reduce(map, %{}, fn {key, value}, acc ->
           Elixir.Map.put(acc, key, unquote(value_function_name)(value))
         end)
       end
+
+      unquote(inner)
     end
   end
 

--- a/test/list_of_maps_schemas/ListOfMaps.avsc
+++ b/test/list_of_maps_schemas/ListOfMaps.avsc
@@ -1,0 +1,17 @@
+{
+    "type": "record",
+    "name": "ListOfMaps",
+    "namespace": "list_of_maps_schemas",
+    "fields": [
+        {
+      "name": "recipients",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "map",
+          "values": ["null", "string"]
+        }
+      }
+    }
+    ]
+}

--- a/test/list_of_maps_test.exs
+++ b/test/list_of_maps_test.exs
@@ -26,21 +26,19 @@ defmodule Avrogen.MapNoWarningsTest do
       # Generate code
       generated_code = SchemaHelpers.generate_code_from_schema(schema)
 
-      # Compile with diagnostics to capture warnings
-      {_result, diagnostics} =
-        Code.with_diagnostics(fn -> Code.compile_string(generated_code) end)
-
-      # Check for clause grouping warnings
-      clause_warnings =
-        Enum.filter(diagnostics, fn diagnostic ->
-          String.contains?(
-            diagnostic.message,
-            "clauses with the same name and arity (number of arguments) should be grouped together,"
-          )
+      # Compile and capture warnings
+      warnings =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          Code.compile_string(generated_code)
         end)
 
-      assert clause_warnings == [],
-             "Expected no clause grouping warnings, but got:\n#{inspect(clause_warnings, pretty: true)}"
+      # Check for clause grouping warnings
+      assert warnings == "" or
+               not String.contains?(
+                 warnings,
+                 "clauses with the same name and arity (number of arguments) should be grouped together"
+               ),
+             "Expected no clause grouping warnings, but got:\n#{warnings}"
     end
   end
 end

--- a/test/list_of_maps_test.exs
+++ b/test/list_of_maps_test.exs
@@ -1,4 +1,4 @@
-defmodule Avrogen.MapNoWarningsTest do
+defmodule Avrogen.ListOfMapsTest do
   @moduledoc """
   Tests that array fields containing maps with union type values don't generate compilation warnings.
 
@@ -23,7 +23,6 @@ defmodule Avrogen.MapNoWarningsTest do
     test "compiles without clause grouping warnings" do
       schema = File.read!(Path.join(@schemas_dir, "ListOfMaps.avsc"))
 
-      # Generate code
       generated_code = SchemaHelpers.generate_code_from_schema(schema)
 
       # Compile and capture warnings
@@ -33,11 +32,10 @@ defmodule Avrogen.MapNoWarningsTest do
         end)
 
       # Check for clause grouping warnings
-      assert warnings == "" or
-               not String.contains?(
-                 warnings,
-                 "clauses with the same name and arity (number of arguments) should be grouped together"
-               ),
+      refute String.contains?(
+               warnings,
+               "clauses with the same name and arity (number of arguments) should be grouped together"
+             ),
              "Expected no clause grouping warnings, but got:\n#{warnings}"
     end
   end

--- a/test/list_of_maps_test.exs
+++ b/test/list_of_maps_test.exs
@@ -1,0 +1,46 @@
+defmodule Avrogen.MapNoWarningsTest do
+  @moduledoc """
+  Tests that array fields containing maps with union type values don't generate compilation warnings.
+
+  The warning that was fixed:
+  "clauses with the same name and arity (number of arguments) should be grouped together"
+
+  This occurred with schemas like:
+  - Field type: array
+  - Items: map
+  - Map values: union type (e.g., ["null", "string"])
+
+  The fix ensures the main encoding function is defined BEFORE its helper functions,
+  so that all helper function clauses are properly grouped together.
+  """
+  use ExUnit.Case, async: false
+
+  alias Avrogen.Test.SchemaHelpers
+
+  @schemas_dir "test/list_of_maps_schemas"
+
+  describe "map encode function" do
+    test "compiles without clause grouping warnings" do
+      schema = File.read!(Path.join(@schemas_dir, "ListOfMaps.avsc"))
+
+      # Generate code
+      generated_code = SchemaHelpers.generate_code_from_schema(schema)
+
+      # Compile with diagnostics to capture warnings
+      {_result, diagnostics} =
+        Code.with_diagnostics(fn -> Code.compile_string(generated_code) end)
+
+      # Check for clause grouping warnings
+      clause_warnings =
+        Enum.filter(diagnostics, fn diagnostic ->
+          String.contains?(
+            diagnostic.message,
+            "clauses with the same name and arity (number of arguments) should be grouped together,"
+          )
+        end)
+
+      assert clause_warnings == [],
+             "Expected no clause grouping warnings, but got:\n#{inspect(clause_warnings, pretty: true)}"
+    end
+  end
+end

--- a/test/support/schema_helpers.ex
+++ b/test/support/schema_helpers.ex
@@ -26,8 +26,7 @@ defmodule Avrogen.Test.SchemaHelpers do
   def generate_code_from_schema(schema) do
     schema
     |> generate_code()
-    |> Enum.map(&IO.iodata_to_binary/1)
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", &IO.iodata_to_binary/1)
   end
 
   # Gets the module name of the record type generated code

--- a/test/support/schema_helpers.ex
+++ b/test/support/schema_helpers.ex
@@ -19,6 +19,17 @@ defmodule Avrogen.Test.SchemaHelpers do
     |> List.first()
   end
 
+  @doc """
+  Generates code from an Avro schema string.
+  The schema is parsed and code is generated but not compiled.
+  """
+  def generate_code_from_schema(schema) do
+    schema
+    |> generate_code()
+    |> Enum.map(&IO.iodata_to_binary/1)
+    |> Enum.join("\n")
+  end
+
   # Gets the module name of the record type generated code
   defp module_name([_, {mod_name, _}]), do: mod_name
   defp module_name(_), do: nil


### PR DESCRIPTION
Reordered `*_values` function clauses to prevent the warning `clauses with the same name and arity should be grouped together` in case of a `list of maps` field

before:
```
  defp encode_recipients(value) when is_list(value) do
    Enum.map(value, fn item -> encode_recipients(item) end)
  end

  [
    defp encode_recipients_values(nil) do
      nil
    end,
    defp encode_recipients_values(value) when is_binary(value) or is_atom(value) do
      value
    end
  ]

  defp encode_recipients(map) when is_map(map) do
    Enum.reduce(map, %{}, fn {key, value}, acc ->
        Elixir.Map.put(acc, key, encode_recipients_values(value))
    end)
  end
```

after:
```
  defp encode_recipients(value) when is_list(value) do
    Enum.map(value, fn item -> encode_recipients(item) end)
  end

  defp encode_recipients(map) when is_map(map) do
    Enum.reduce(map, %{}, fn {key, value}, acc ->
        Elixir.Map.put(acc, key, encode_recipients_values(value))
    end)
  end

  [
    defp encode_recipients_values(nil) do
      nil
    end,
    defp encode_recipients_values(value) when is_binary(value) or is_atom(value) do
      value
    end
  ]
```

> [!NOTE]
> This changes is going to affect fields of type `list of Maps`, but also simple `Map`, placing the `encode_*_values` after the `encode_*` function...