### PR TITLE
Bug: boolean with true as default are always true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ---
 
+## [0.11.3] - 2026-03-19
+
+### Fixed
+- A bug in the code generation causing boolean properties with default value == true to deserialize always as true
+
+---
+
 ## [0.11.2] - 2026-03-05
 
 ### Fixed
@@ -138,7 +145,9 @@ and this project adheres to
   - `LocalTimestampMillis` (`long`).
   - `LocalTimestampMicros` (`long`).
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.11.2...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/0.11.3...HEAD
+[0.11.3]: https://github.com/primait/avrogen/compare/0.11.2...0.11.3
 [0.11.2]: https://github.com/primait/avrogen/compare/0.11.1...0.11.2
 [0.11.1]: https://github.com/primait/avrogen/compare/0.11.0...0.11.1
 [0.11.0]: https://github.com/primait/avrogen/compare/0.10.0...0.11.0

--- a/lib/avrogen/avro/types/record/field.ex
+++ b/lib/avrogen/avro/types/record/field.ex
@@ -81,7 +81,7 @@ defmodule Avrogen.Avro.Types.Record.Field do
         quote(do: unquote(variable_name) = avro_map[unquote(name)])
 
       default ->
-        quote(do: unquote(variable_name) = avro_map[unquote(name)] || unquote(default))
+        quote(do: unquote(variable_name) = Map.get(avro_map, unquote(name), unquote(default)))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.11.2"
+  @version "0.11.3"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/test/roundtrip_schemas/BooleanDefaultRecord.avsc
+++ b/test/roundtrip_schemas/BooleanDefaultRecord.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "BooleanDefaultRecord",
+  "namespace": "events.v1",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "is_active",
+      "type": "boolean",
+      "default": true
+    }
+  ]
+}

--- a/test/roundtrip_test.exs
+++ b/test/roundtrip_test.exs
@@ -33,6 +33,28 @@ defmodule Avrogen.Test.Roundtrip do
     end
   end)
 
+  test "roundtrip preserves explicit false for boolean fields with default true" do
+    schema = File.read!(Path.join(@schemas_dir, "BooleanDefaultRecord.avsc"))
+
+    module =
+      schema
+      |> generate_code()
+      |> Enum.map(&compile_code/1)
+      |> Enum.map(&module_name/1)
+      |> Enum.reject(&is_nil/1)
+      |> List.first()
+
+    input = struct(module, id: "test_id", is_active: false)
+    encoder = SchemaRegistry.make_encoder(schema)
+    decoder = SchemaRegistry.make_decoder(schema)
+
+    encoded = encoder.(module.avro_fqn(), module.to_avro_map(input))
+    {:ok, decoded} = decoder.(module.avro_fqn(), encoded) |> module.from_avro_map()
+
+    assert decoded.is_active == false
+    assert input == decoded
+  end
+
   # Gets the module name of the record type generated code
   defp module_name([_, {mod_name, _}]), do: mod_name
   defp module_name(_), do: nil


### PR DESCRIPTION
Ciao! 
When writing an integration test using the `avrogen` generated code I've found that a schema with a boolean field with a default set to true will always be true no matter the value, due to this line `lib/avrogen/avro/types/record/field.ex:84` 

```elixir
 # false || true is always true
quote(do: unquote(variable_name) = avro_map[unquote(name)] || unquote(default))
```

I've added a test, which fails with the code as is, and a possible fix. 
TX!
