### PR TITLE
Implement Inspect protocol for generated structs to redact PII fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ---
 
+## [0.11.4] - 2026-05-08
+
+### Added
+- Implemented the `Inspect` protocol for generated structs to redact PII fields.
+
+---
+
 ## [0.11.3] - 2026-03-19
 
 ### Fixed
@@ -146,7 +153,9 @@ and this project adheres to
   - `LocalTimestampMicros` (`long`).
 
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.11.3...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/0.11.4...HEAD
+[0.11.4]: https://github.com/primait/avrogen/compare/0.11.3...0.11.4
 [0.11.3]: https://github.com/primait/avrogen/compare/0.11.2...0.11.3
 [0.11.2]: https://github.com/primait/avrogen/compare/0.11.1...0.11.2
 [0.11.1]: https://github.com/primait/avrogen/compare/0.11.0...0.11.1

--- a/lib/avrogen/avro/types/record.ex
+++ b/lib/avrogen/avro/types/record.ex
@@ -61,6 +61,8 @@ defmodule Avrogen.Avro.Types.Record do
           (unquote_splicing(Enum.map(record.fields, &__MODULE__.Field.typed_struct_field/1)))
         end
 
+        unquote(inspect_impl(record))
+
         @behaviour Avrogen.AvroModule
 
         @impl true
@@ -181,6 +183,36 @@ defmodule Avrogen.Avro.Types.Record do
     fields
     |> Enum.filter(&Field.is_pii?/1)
     |> Enum.map(&Field.name/1)
+  end
+
+  defp inspect_impl(%__MODULE__{} = record) do
+    pii_atoms = record |> pii_keys() |> Enum.map(&String.to_atom/1)
+
+    case pii_atoms do
+      [] ->
+        quote do
+        end
+
+      _ ->
+        quote do
+          defimpl Inspect do
+            defp redact_field({k, _v}) when k in unquote(pii_atoms), do: {k, "**REDACTED**"}
+            defp redact_field(pair), do: pair
+
+            def inspect(struct, opts) do
+              redacted = struct |> Map.from_struct() |> Enum.map(&redact_field/1)
+
+              Inspect.Algebra.concat([
+                "#",
+                Kernel.to_string(unquote(record.name)),
+                "<",
+                Inspect.Algebra.to_doc(redacted, opts),
+                ">"
+              ])
+            end
+          end
+        end
+    end
   end
 
   defp drop_pii(%__MODULE__{fields: fields}, global) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.11.3"
+  @version "0.11.4"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/test/inspect_pii_test.exs
+++ b/test/inspect_pii_test.exs
@@ -1,0 +1,86 @@
+defmodule Avrogen.Test.InspectPii do
+  use ExUnit.Case, async: false
+
+  alias Avrogen.Avro.Schema
+
+  @schema_file "test/roundtrip_schemas/PersonWithPii.avsc"
+
+  setup_all do
+    Code.put_compiler_option(:ignore_already_consolidated, true)
+    Code.put_compiler_option(:ignore_module_conflict, true)
+    Code.put_compiler_option(:no_warn_undefined, :all)
+
+    schema = File.read!(@schema_file)
+
+    modules =
+      schema
+      |> Jason.decode!()
+      |> Schema.generate_code([], "Test")
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.map(&IO.iodata_to_binary/1)
+      |> Enum.flat_map(&Code.compile_string/1)
+      |> Enum.map(&elem(&1, 0))
+
+    record_module =
+      Enum.find(modules, fn mod ->
+        Code.ensure_loaded?(mod) and function_exported?(mod, :pii_fields, 0)
+      end)
+
+    %{record_module: record_module}
+  end
+
+  describe "Inspect protocol for records with PII fields" do
+    test "redacts PII fields in inspect output", %{record_module: record_module} do
+      struct =
+        struct(record_module,
+          id: "123",
+          full_name: "John Doe",
+          email: "john@example.com",
+          age: 30
+        )
+
+      # Call the generated Inspect impl directly (bypassing consolidated protocol dispatch)
+      inspect_impl = Module.concat(Inspect, record_module)
+      doc = inspect_impl.inspect(struct, %Inspect.Opts{})
+      inspected = doc |> Inspect.Algebra.format(80) |> IO.iodata_to_binary()
+
+      refute inspected =~ "John Doe"
+      refute inspected =~ "john@example.com"
+      assert inspected =~ "**REDACTED**"
+      assert inspected =~ "123"
+      assert inspected =~ "30"
+    end
+
+    test "PII fields are listed in pii_fields/0", %{record_module: record_module} do
+      pii = record_module.pii_fields()
+
+      assert MapSet.member?(pii, "full_name")
+      assert MapSet.member?(pii, "email")
+      refute MapSet.member?(pii, "id")
+      refute MapSet.member?(pii, "age")
+    end
+  end
+
+  describe "Inspect protocol for records without PII fields" do
+    test "no custom Inspect impl is generated" do
+      schema = File.read!("test/roundtrip_schemas/TestRecord1.avsc")
+
+      modules =
+        schema
+        |> Jason.decode!()
+        |> Schema.generate_code([], "NoPii")
+        |> Enum.map(&elem(&1, 1))
+        |> Enum.map(&IO.iodata_to_binary/1)
+        |> Enum.flat_map(&Code.compile_string/1)
+        |> Enum.map(&elem(&1, 0))
+
+      record_module =
+        Enum.find(modules, fn mod ->
+          Code.ensure_loaded?(mod) and function_exported?(mod, :pii_fields, 0)
+        end)
+
+      inspect_impl = Module.concat(Inspect, record_module)
+      refute Code.ensure_loaded?(inspect_impl)
+    end
+  end
+end

--- a/test/roundtrip_schemas/PersonWithPii.avsc
+++ b/test/roundtrip_schemas/PersonWithPii.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "PersonWithPii",
+  "namespace": "events.v1",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "full_name",
+      "type": ["null", "string"],
+      "pii": true
+    },
+    {
+      "name": "email",
+      "type": ["null", "string"],
+      "pii": true
+    },
+    {
+      "name": "age",
+      "type": "int"
+    }
+  ]
+}


### PR DESCRIPTION
### Problem

When generated Avro structs end up in logs (via `Logger`, `IO.inspect/2`, exception messages, etc.), PII-marked fields are displayed in plain text. This is a data privacy concern, IMHO.

### Solution

For every record schema that has fields marked with `"pii": true`, the code generator now produces a `defimpl Inspect` that replaces PII field values with `**REDACTED**` in the inspect output. Records without PII fields are not affected — no custom Inspect implementation is generated.

#### Example

Given a schema with `full_name` and `email` marked as PII:

```elixir
# Before (PII leaked in logs)
#=> %Events.V1.Person{id: "123", full_name: "John Doe", email: "john@example.com", age: 30}

# After (PII redacted)
#=> #PersonWithPii<[id: "123", full_name: "**REDACTED**", email: "**REDACTED**", age: 30]>