### PR TITLE
Avoid injecting nil in generated modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ---
 
+## [0.11.5] - 2026-05-25
+
+### Fixed
+
+- Fixed generated modules including a stray `nil` when no pii fields were present.
+
+---
+
 ## [0.11.4] - 2026-05-08
 
 ### Added
@@ -154,7 +162,9 @@ and this project adheres to
 
 
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.11.4...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/0.11.5...HEAD
+[0.11.5]: https://github.com/primait/avrogen/compare/0.11.4...0.11.5
 [0.11.4]: https://github.com/primait/avrogen/compare/0.11.3...0.11.4
 [0.11.3]: https://github.com/primait/avrogen/compare/0.11.2...0.11.3
 [0.11.2]: https://github.com/primait/avrogen/compare/0.11.1...0.11.2

--- a/lib/avrogen/avro/types/record.ex
+++ b/lib/avrogen/avro/types/record.ex
@@ -61,7 +61,7 @@ defmodule Avrogen.Avro.Types.Record do
           (unquote_splicing(Enum.map(record.fields, &__MODULE__.Field.typed_struct_field/1)))
         end
 
-        unquote(inspect_impl(record))
+        unquote_splicing(inspect_impl(record))
 
         @behaviour Avrogen.AvroModule
 
@@ -190,28 +190,29 @@ defmodule Avrogen.Avro.Types.Record do
 
     case pii_atoms do
       [] ->
-        quote do
-        end
+        []
 
       _ ->
-        quote do
-          defimpl Inspect do
-            defp redact_field({k, _v}) when k in unquote(pii_atoms), do: {k, "**REDACTED**"}
-            defp redact_field(pair), do: pair
+        [
+          quote do
+            defimpl Inspect do
+              defp redact_field({k, _v}) when k in unquote(pii_atoms), do: {k, "**REDACTED**"}
+              defp redact_field(pair), do: pair
 
-            def inspect(struct, opts) do
-              redacted = struct |> Map.from_struct() |> Enum.map(&redact_field/1)
+              def inspect(struct, opts) do
+                redacted = struct |> Map.from_struct() |> Enum.map(&redact_field/1)
 
-              Inspect.Algebra.concat([
-                "#",
-                Kernel.to_string(unquote(record.name)),
-                "<",
-                Inspect.Algebra.to_doc(redacted, opts),
-                ">"
-              ])
+                Inspect.Algebra.concat([
+                  "#",
+                  Kernel.to_string(unquote(record.name)),
+                  "<",
+                  Inspect.Algebra.to_doc(redacted, opts),
+                  ">"
+                ])
+              end
             end
           end
-        end
+        ]
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "0.11.4"
+  @version "0.11.5"
   @source_url "https://github.com/primait/avrogen"
 
   def project do


### PR DESCRIPTION
After primait/avrogen#45, records generated from schemas without any pii fields ended up with a stray `nil` in the module body.

The issue was in the `Inspect` code generation path: in the empty case, `inspect_impl/1` returned an empty quoted block, and unquoting that produces `nil`, which then got injected into the generated module. This change fixes it by returning an empty list instead and using `unquote_splicing`, so nothing gets emitted when there is no `Inspect` impl to generate.

When `pii` fields are present, the custom `Inspect` implementation is still generated as before.