### PR TITLE
[BREAKING CHANGE] remove rubbish-in-rubbish-out union decode hack

### DIFF
--- a/lib/avrogen/avro/types/union.ex
+++ b/lib/avrogen/avro/types/union.ex
@@ -89,10 +89,7 @@ defimpl CodeGenerator, for: Union do
     quote do
       defp unquote(function_name)(value) do
         with unquote_splicing(clauses) do
-          # This is not correct behaviour, but is the current behaviour of the library.
-          # We should remove this and return an error here instead but too many tests
-          # in pricing depended on this behaviour.
-          {:ok, value}
+          {:error, "Failed to decode union value #{inspect(value)}"}
         end
       end
 

--- a/test/avro/types/union_test.exs
+++ b/test/avro/types/union_test.exs
@@ -50,9 +50,7 @@ defmodule Avrogen.Avro.Types.UnionTest do
     end
 
     test "union function clause error trying to decode a non-union type" do
-      # assert {:error, _} = test_decode_union_primitives(%{})
-      # Note: that's not the correct behavior. The function should return an error.
-      assert {:ok, %{}} = test_decode_union_primitives(%{})
+      assert {:error, _} = test_decode_union_primitives(%{})
     end
   end
 end


### PR DESCRIPTION
This hack was in place for one specific client of the library, which has since been fixed.