### PR TITLE
fix staleness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to
 
 ---
 
+## [1.1.0] - 2026-07-06
+
+- Fix stale detection in `Mix.Tasks.Compile.AvroCodeGenerator` so schemas are regenerated when source and target mtimes are equal.
+- Refactor stale-check input handling and add optional debug output for stale decisions via `AVROGEN_DEBUG_STALE=1`.
+- Bump `uniq` from 0.6.1 to 0.6.3.
+- Bump `decimal` from 2.4.1 to 3.1.1.
+- Bump `ex_doc` from 0.34.2 to 0.40.3.
+- Update CI tooling versions in GitHub Actions workflows:
+  - `actions/checkout` from 3 to 7.0.0 (via incremental updates).
+  - `actions/cache` from 3 to 6.1.0 (via incremental updates).
+  - `erlef/setup-beam` from 1 to 1.24.0.
+
+---
+
 ## [1.0.0] - 2026-06-18 
 
 - [BREAKING CHANGE] Add support for elixir 1.17 and drop support for lower elixir versions
@@ -185,7 +199,9 @@ and this project adheres to
 
 
 
-[Unreleased]: https://github.com/primait/avrogen/compare/0.12.1...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/primait/avrogen/compare/1.0.0...1.1.0
 [0.12.1]: https://github.com/primait/avrogen/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/primait/avrogen/compare/0.11.5...0.12.0
 [0.11.5]: https://github.com/primait/avrogen/compare/0.11.4...0.11.5

--- a/lib/mix/tasks/avrogen_code_generator.ex
+++ b/lib/mix/tasks/avrogen_code_generator.ex
@@ -220,10 +220,23 @@ defmodule Mix.Tasks.Compile.AvroCodeGenerator do
 
     paths = Avrogen.Avro.Schema.filenames_from_schema(dest, schema)
 
+    stale_due_to_equal_mtime =
+      case paths do
+        [] ->
+          false
+
+        _ ->
+          modified_target = paths |> Enum.map(&Mix.Utils.last_modified/1) |> Enum.min()
+          Mix.Utils.last_modified(path_to_schema) == modified_target
+      end
+
     status =
-      case force || Mix.Utils.stale?(paths ++ deps ++ find_beam_files(), paths) do
-        true -> :stale
-        false -> :noop
+      if force ||
+           Mix.Utils.stale?([path_to_schema ++ deps ++ find_beam_files()], paths) ||
+           stale_due_to_equal_mtime do
+        :stale
+      else
+        :noop
       end
 
     {status, path_to_schema, deps, paths, scope}

--- a/lib/mix/tasks/avrogen_code_generator.ex
+++ b/lib/mix/tasks/avrogen_code_generator.ex
@@ -230,10 +230,22 @@ defmodule Mix.Tasks.Compile.AvroCodeGenerator do
           Mix.Utils.last_modified(path_to_schema) == modified_target
       end
 
+    stale_sources = [path_to_schema] ++ deps ++ find_beam_files()
+
+    stale_due_to_inputs = Mix.Utils.stale?(stale_sources, paths)
+
+    debug_stale_check(
+      path_to_schema,
+      paths,
+      deps,
+      stale_sources,
+      stale_due_to_inputs,
+      stale_due_to_equal_mtime,
+      force
+    )
+
     status =
-      if force ||
-           Mix.Utils.stale?([path_to_schema ++ deps ++ find_beam_files()], paths) ||
-           stale_due_to_equal_mtime do
+      if force || stale_due_to_inputs || stale_due_to_equal_mtime do
         :stale
       else
         :noop
@@ -384,5 +396,26 @@ defmodule Mix.Tasks.Compile.AvroCodeGenerator do
   defp log(message) do
     print_app_name()
     IO.puts(message)
+  end
+
+  defp debug_stale_check(
+         path_to_schema,
+         paths,
+         deps,
+         stale_sources,
+         stale_due_to_inputs,
+         stale_due_to_equal_mtime,
+         force
+       ) do
+    if System.get_env("AVROGEN_DEBUG_STALE") in ["1", "true", "TRUE"] do
+      Mix.shell().info("[avrogen][stale] path_to_schema=#{path_to_schema}")
+      Mix.shell().info("[avrogen][stale] paths(targets)=#{inspect(paths)}")
+      Mix.shell().info("[avrogen][stale] deps=#{inspect(deps)}")
+      Mix.shell().info("[avrogen][stale] stale_sources=#{inspect(stale_sources)}")
+
+      Mix.shell().info(
+        "[avrogen][stale] force=#{force} stale_due_to_inputs=#{stale_due_to_inputs} stale_due_to_equal_mtime=#{stale_due_to_equal_mtime}"
+      )
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.1.0"
   @source_url "https://github.com/primait/avrogen"
 
   def project do


### PR DESCRIPTION
Locally (I don't know in CI) we often have compilation issues due to elixir structs not being updated.

I could reproduce this locally in one of our project by simply checking out an old schema (let's say with a missing field), then doing `mix compile.avro_code_generator`, then restoring the current schema, finally running `mix compile.avro_code_generator` doesn't regenerate the struct.

I wonder if we actually meant to have `path_to_schema` instead of `path` in the staleness [check](https://github.com/primait/avrogen/blob/b3bbb58f09013cb5342fc6134cf80b4a709c9b47/lib/mix/tasks/avrogen_code_generator.ex#L224).

I also made an additional fix to consider stale also sources and targets that have been modified at the same second, since currently they are not considered stale. I think this would be safer in case we use this with cache layers that incorrectly modifies the mtime of files. The worst that can happen is that we trigger recompilation once more.

UPDATE:
In the second commit I have introduced optional debugging output during compilation.
This is an example (some parts removed) for one avsc file:
```
[avrogen][stale] path_to_schema=priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/policy/Person.avsc
[avrogen][stale] paths(targets)=["lib/claims_modeling_backend/generated/event/com/helloprima/claims/cgp/claim/value_object/policy/person.ex"]
[avrogen][stale] deps=["priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/LicenceType.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/PersonType.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/RelationToPolicyholder.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/Location.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/UkLocation.avsc"]
[avrogen][stale] stale_sources=["priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/policy/Person.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/LicenceType.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/PersonType.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/enum/RelationToPolicyholder.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/Location.avsc", "priv/schemas/avro/com/helloprima/claims/cgp/claim/value_object/UkLocation.avsc", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Array.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Enum.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Logical.BigDecimal.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Logical.Date.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Logical.DateString.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Logical.DateTimeString.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Schema.CodeGenerator.Avrogen.Avro.Types.Logical.Decimal.beam", "/code/_build/dev/lib/avrogen/ebin/
...
Elixir.Avrogen.Avro.Types.Logical.DurationString.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.LocalTimestampMicros.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.LocalTimestampMillis.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.TimeMicros.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.TimeMillis.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.TimestampMicros.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.TimestampMillis.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.UUID.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Logical.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Map.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Primitive.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Record.Field.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Record.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Avrogen.Avro.Types.Reference.beam", ....
Elixir.Jason.Encoder.Avrogen.Avro.Types.Logical.TimestampMicros.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Logical.TimestampMillis.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Logical.UUID.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Map.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Primitive.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Record.Field.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Record.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Reference.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Jason.Encoder.Avrogen.Avro.Types.Union.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Mix.Tasks.Compile.AvroCodeGenerator.Manifest.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Mix.Tasks.Compile.AvroCodeGenerator.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Mix.Tasks.Compile.AvroSchemaGenerator.Manifest.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Mix.Tasks.Compile.AvroSchemaGenerator.TaskSummary.beam", "/code/_build/dev/lib/avrogen/ebin/Elixir.Mix.Tasks.Compile.AvroSchemaGenerator.beam", "/code/_build/dev/lib/avrogen/ebin/avrogen.app"]
[avrogen][stale] force=false stale_due_to_inputs=false stale_due_to_equal_mtime=false
```