### PR TITLE
Support both decimal 2 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ---
 
+## [1.1.1] - 2026-07-28
+
+- Relax `decimal` dependency to support both 2.x and 3.x.
+
+---
+
 ## [1.1.0] - 2026-07-06
 
 - Fix stale detection in `Mix.Tasks.Compile.AvroCodeGenerator` so schemas are regenerated when source and target mtimes are equal.
@@ -200,7 +206,9 @@ and this project adheres to
 
 
 
-[Unreleased]: https://github.com/primait/avrogen/compare/1.1.0...HEAD
+
+[Unreleased]: https://github.com/primait/avrogen/compare/1.1.1...HEAD
+[1.1.1]: https://github.com/primait/avrogen/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/primait/avrogen/compare/1.0.0...1.1.0
 [0.12.1]: https://github.com/primait/avrogen/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/primait/avrogen/compare/0.11.5...0.12.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Avrogen.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
   @source_url "https://github.com/primait/avrogen"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Avrogen.MixProject do
     [
       {:accessible, "~> 0.3"},
       {:credo, "~> 1.7.0", only: [:dev, :test], runtime: false},
-      {:decimal, "~> 3.1"},
+      {:decimal, "~> 2.0 or ~> 3.0"},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:erlavro, "~> 2.9"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Since decimal dep was bumped in #62 without any change to the code, I expect supporting both decimal 2 and 3 is fine and clients are not forced to bump on decimal 3.
