### PR TITLE
Replace Timex with Elixir stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `Timex` with Elixir stdlib (`NaiveDateTime`, `DateTime`) in `local_timestamp_millis`, `local_timestamp_micros`, and `Random.datetime/3`. This removes `timex` and its transitive dependencies from the dependency tree.
+
 ---
 
 ## [1.1.2] - 2026-08-17

--- a/lib/avrogen/avro/types/logical/local_timestamp_micros.ex
+++ b/lib/avrogen/avro/types/logical/local_timestamp_micros.ex
@@ -41,7 +41,7 @@ defimpl CodeGenerator, for: LocalTimestampMicros do
   def encode_function(%LocalTimestampMicros{}, function_name, _global) do
     quote do
       defp unquote(function_name)(%NaiveDateTime{} = timestamp),
-        do: Timex.diff(timestamp, ~N[1970-01-01 00:00:00.000000], :microsecond)
+        do: NaiveDateTime.diff(timestamp, ~N[1970-01-01 00:00:00.000000], :microsecond)
     end
   end
 
@@ -49,8 +49,7 @@ defimpl CodeGenerator, for: LocalTimestampMicros do
     quote do
       defp unquote(function_name)(timestamp) when is_number(timestamp),
         do:
-          {:ok,
-           Timex.add(~N[1970-01-01 00:00:00.000000], Timex.Duration.from_microseconds(timestamp))}
+          {:ok, NaiveDateTime.add(~N[1970-01-01 00:00:00.000000], timestamp, :microsecond)}
 
       defp unquote(function_name)(timestamp),
         do: {:error, "Expected a long value, got: #{inspect(timestamp)}"}

--- a/lib/avrogen/avro/types/logical/local_timestamp_millis.ex
+++ b/lib/avrogen/avro/types/logical/local_timestamp_millis.ex
@@ -41,7 +41,7 @@ defimpl CodeGenerator, for: LocalTimestampMillis do
   def encode_function(%LocalTimestampMillis{}, function_name, _global) do
     quote do
       defp unquote(function_name)(%NaiveDateTime{} = timestamp),
-        do: Timex.diff(timestamp, ~N[1970-01-01 00:00:00.000000], :millisecond)
+        do: NaiveDateTime.diff(timestamp, ~N[1970-01-01 00:00:00.000000], :millisecond)
     end
   end
 
@@ -49,8 +49,7 @@ defimpl CodeGenerator, for: LocalTimestampMillis do
     quote do
       defp unquote(function_name)(timestamp) when is_number(timestamp),
         do:
-          {:ok,
-           Timex.add(~N[1970-01-01 00:00:00.000000], Timex.Duration.from_milliseconds(timestamp))}
+          {:ok, NaiveDateTime.add(~N[1970-01-01 00:00:00.000000], timestamp, :millisecond)}
 
       defp unquote(function_name)(timestamp),
         do: {:error, "Expected a long value, got: #{inspect(timestamp)}"}

--- a/lib/avrogen/util/random.ex
+++ b/lib/avrogen/util/random.ex
@@ -306,15 +306,15 @@ defmodule Avrogen.Util.Random do
   """
   def datetime(rand_state, start_date, end_date) do
     {end_d, start_d} =
-      case Timex.compare(end_date, start_date) do
-        -1 -> {start_date, end_date}
+      case DateTime.compare(end_date, start_date) do
+        :lt -> {start_date, end_date}
         _ -> {end_date, start_date}
       end
 
-    range = abs(Timex.diff(end_d, start_d, :milliseconds))
+    range = abs(DateTime.diff(end_d, start_d, :millisecond))
     {s, millis} = integer(rand_state, 0, range)
 
-    d = Timex.add(start_d, Timex.Duration.from_milliseconds(millis))
+    d = DateTime.add(start_d, millis, :millisecond)
     {s, d}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,6 @@ defmodule Avrogen.MixProject do
       {:excribe, "~> 0.1"},
       {:jason, "~> 1.0"},
       {:libgraph, "~> 0.16"},
-      {:timex, "~> 3.6"},
       {:typed_struct, "~> 0.3"},
       {:uniq, "~> 0.1"}
     ]


### PR DESCRIPTION
## Motivation

Timex pulls in tzdata, which depends on hackney. Hackney has known security vulnerabilities and is effectively unmaintained, but tzdata pins it as a hard dependency — so as long as Timex is in the tree, hackney stays too.

This is safe to remove because the Elixir stdlib (>= 1.17, already the floor in mix.exs) now covers everything avrogen uses from Timex: `NaiveDateTime.diff/3`, `NaiveDateTime.add/3`, `DateTime.diff/3`, `DateTime.add/3`, and `DateTime.compare/2`. In fact, all other logical types in the codebase already use the stdlib — only three files still called Timex.

## Proposed Solution

Replace the remaining Timex calls with their stdlib equivalents and remove `{:timex, "~> 3.6"}` from `mix.exs`:

- `local_timestamp_millis.ex` and `local_timestamp_micros.ex`: `Timex.diff` / `Timex.add` + `Timex.Duration` → `NaiveDateTime.diff/3` / `NaiveDateTime.add/3`
- `util/random.ex`: `Timex.compare` / `Timex.diff` / `Timex.add` → `DateTime.compare/2` / `DateTime.diff/3` / `DateTime.add/3`

This drops Timex and its entire transitive chain (combine, gettext, expo, tzdata, hackney, certifi, and friends) from the dependency tree.